### PR TITLE
Ensure create_releases job runs regardless of previous job outcomes i…

### DIFF
--- a/.github/workflows/generate-openwrt.yml
+++ b/.github/workflows/generate-openwrt.yml
@@ -325,6 +325,7 @@ jobs:
 
   create_releases:
     needs: [prepare, build]
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
…n generate-openwrt workflow